### PR TITLE
Delete sprints

### DIFF
--- a/backend/src/controllers/release.ts
+++ b/backend/src/controllers/release.ts
@@ -40,6 +40,6 @@ export const copyRelease = async (req: express.Request, res: express.Response) =
 export const getRelease = async (req: express.Request, res: express.Response) => {
 	const db = Database.getInstance()
 	const {releaseId} = req.params;
-	const release = await db.lookupReleaseWithProject(parseInt(releaseId))
+	const release = await db.fetchReleaseWithProject(parseInt(releaseId))
 	return res.json(release)
 };

--- a/backend/src/controllers/sprint.ts
+++ b/backend/src/controllers/sprint.ts
@@ -39,9 +39,9 @@ export const getSprints = async(req: express.Request, res: express.Response) => 
 
 export const getSprintWithRelease = async(req: express.Request, res: express.Response) => {
 	const db = Database.getInstance()
-	const { releaseId } = req.params
-	if (!verifyParameters(releaseId)) return res.sendStatus(400)
-	const sprintList = await db.getReleaseSprints(parseInt(releaseId))
+	const { sprintId } = req.params
+	if (!verifyParameters(sprintId)) return res.sendStatus(400)
+	const sprintList = await db.lookupSprintByIdWithRelease(parseInt(sprintId))
 	return res.json(sprintList)
 }
 

--- a/backend/src/controllers/sprint.ts
+++ b/backend/src/controllers/sprint.ts
@@ -56,3 +56,11 @@ export const moveSprint = async(req: express.Request, res: express.Response) => 
 	const sprintList = await db.reorderSprints(parseInt(releaseId), parseInt(sprintStartIndex), parseInt(sprintEndIndex))
 	return res.json(sprintList)
 }
+
+export const deleteSprint = async(req: express.Request, res: express.Response) => {
+	const db = Database.getInstance()
+	const { sprintId } = req.params
+	if (!verifyParameters(sprintId)) return res.sendStatus(400)
+	const newSprintList = await db.removeSprintFromRelease(parseInt(sprintId))
+	return res.json(newSprintList)
+}

--- a/backend/src/controllers/sprint.ts
+++ b/backend/src/controllers/sprint.ts
@@ -28,3 +28,11 @@ export const editSprint = async(req: express.Request, res: express.Response) => 
 	const sprint = await db.updateSprint(parseInt(sprintId), sprintNumber, startDate, endDate, goal)
 	return res.json(sprint)
 }
+
+export const getSprints = async(req: express.Request, res: express.Response) => {
+	const db = Database.getInstance()
+	const { releaseId } = req.params
+	if (!verifyParameters(releaseId)) return res.sendStatus(400)
+	const sprintList = await db.getReleaseSprints(parseInt(releaseId))
+	return res.json(sprintList)
+}

--- a/backend/src/controllers/sprint.ts
+++ b/backend/src/controllers/sprint.ts
@@ -36,3 +36,23 @@ export const getSprints = async(req: express.Request, res: express.Response) => 
 	const sprintList = await db.getReleaseSprints(parseInt(releaseId))
 	return res.json(sprintList)
 }
+
+export const getSprintWithRelease = async(req: express.Request, res: express.Response) => {
+	const db = Database.getInstance()
+	const { releaseId } = req.params
+	if (!verifyParameters(releaseId)) return res.sendStatus(400)
+	const sprintList = await db.getReleaseSprints(parseInt(releaseId))
+	return res.json(sprintList)
+}
+
+export const moveSprint = async(req: express.Request, res: express.Response) => {
+	const db = Database.getInstance()
+	const { releaseId } = req.params
+	const {
+		sprintStartIndex,
+		sprintEndIndex
+	} = req.body
+	if (!verifyParameters(releaseId, sprintStartIndex, sprintEndIndex)) return res.sendStatus(400)
+	const sprintList = await db.reorderSprints(parseInt(releaseId), parseInt(sprintStartIndex), parseInt(sprintEndIndex))
+	return res.json(sprintList)
+}

--- a/backend/src/db/dataSourceWrapper.ts
+++ b/backend/src/db/dataSourceWrapper.ts
@@ -49,7 +49,12 @@ export class DataSourceWrapper {
 	}
 
 	public async fetchUserWithProjects(id: number): Promise<User> {
-		const maybeUserList = (await this.dataSource.getRepository(User).find({where: {id: id}, relations:{ownedProjects: true, joinedProjects: true}}))
+		const maybeUserList = await this.dataSource.getRepository(User).find({
+			where: {id: id},
+			relations:{
+				ownedProjects: true,
+				joinedProjects: true
+			}})
 		if (!maybeUserList || maybeUserList.length === 0) {
 			throw new NotFoundError(`User with id ${id} not found`)
 		}
@@ -67,11 +72,16 @@ export class DataSourceWrapper {
 	}
 
 	public async lookupProjectByIdWithUsers(id: number): Promise<Project> {
-		const maybeProject =  (await this.dataSource.getRepository(Project).find({where: {id: id}, relations:{productOwner: true, teamMembers: true}}))[0]
-		if (!maybeProject) {
+		const maybeProject =  await this.dataSource.getRepository(Project).find({
+			where: {id: id},
+			relations:{
+				productOwner: true,
+				teamMembers: true
+			}})
+		if (!maybeProject || maybeProject.length === 0) {
 			throw new NotFoundError(`Project with id ${id} not found`)
 		}
-		return maybeProject
+		return maybeProject[0]
 	}
 
 	public async fetchProjectWithReleases(id: number): Promise<Project> {
@@ -117,12 +127,12 @@ export class DataSourceWrapper {
 	}
 
 	public async fetchReleaseWithSprints(releaseId: number): Promise<Release> {
-		const releaseWithSprints = (await this.dataSource.getRepository(Release).find({
+		const releaseWithSprints = await this.dataSource.getRepository(Release).find({
 			where: {id: releaseId},
 			relations:{
 				sprints: true // must sort by sprint.sprintNumber later
 			},
-		}))
+		})
 		if (!releaseWithSprints || releaseWithSprints.length === 0) {
 			throw new NotFoundError(`Release with releaseId ${releaseId} not found`)
 		}
@@ -147,6 +157,19 @@ export class DataSourceWrapper {
 			throw new NotFoundError(`Sprint with id ${id} not found`)
 		}
 		return maybeSprint
+	}
+	
+	public async lookupSprintByIdWithRelease(id: number): Promise<Sprint> {
+		const maybeSprint = await this.dataSource.getRepository(Sprint).find({
+			where: {id: id},
+			relations:{
+				release: true // must sort by sprint.sprintNumber later
+			},
+		})
+		if (!maybeSprint || maybeSprint.length === 0) {
+			throw new NotFoundError(`Sprint with id ${id} not found`)
+		}
+		return maybeSprint[0]
 	}
 
 	///// Todo Methods /////

--- a/backend/src/db/dataSourceWrapper.ts
+++ b/backend/src/db/dataSourceWrapper.ts
@@ -103,7 +103,7 @@ export class DataSourceWrapper {
 		return maybeRelease
 	}
 
-	public async lookupReleaseWithProject(releaseId: number): Promise<Release> {
+	public async fetchReleaseWithProject(releaseId: number): Promise<Release> {
 		const releaseWithProject = (await this.dataSource.getRepository(Release).find({
 			where: {id: releaseId},
 			relations:{
@@ -113,6 +113,18 @@ export class DataSourceWrapper {
 			throw new NotFoundError(`Release with releaseId ${releaseId} not found`)
 		}
 		return releaseWithProject[0]
+	}
+
+	public async fetchReleaseWithSprints(releaseId: number): Promise<Release> {
+		const releaseWithSprints = (await this.dataSource.getRepository(Release).find({
+			where: {id: releaseId},
+			relations:{
+				sprints: true
+			}}))
+		if (!releaseWithSprints || releaseWithSprints.length === 0) {
+			throw new NotFoundError(`Release with releaseId ${releaseId} not found`)
+		}
+		return releaseWithSprints[0]
 	}
 
 	///// Role Methods /////

--- a/backend/src/db/dataSourceWrapper.ts
+++ b/backend/src/db/dataSourceWrapper.ts
@@ -1,3 +1,4 @@
+import sprint from "router/sprint";
 import { User } from "../entity/User";
 import { BacklogItem, Story } from "../entity/backlogItem";
 import { Project } from "../entity/project";
@@ -170,6 +171,12 @@ export class DataSourceWrapper {
 			throw new NotFoundError(`Sprint with id ${id} not found`)
 		}
 		return maybeSprint[0]
+	}
+	
+	// TODO: handle stories in the sprint
+	// Maybe we can make it soft-delete if we ever implement undo feature
+	public async deleteSprint(id: number): Promise<void> {
+		await this.dataSource.getRepository(Sprint).delete(id)
 	}
 
 	///// Todo Methods /////

--- a/backend/src/db/dataSourceWrapper.ts
+++ b/backend/src/db/dataSourceWrapper.ts
@@ -108,7 +108,8 @@ export class DataSourceWrapper {
 			where: {id: releaseId},
 			relations:{
 				project: true
-			}}))
+			},
+		}))
 		if (!releaseWithProject || releaseWithProject.length === 0) {
 			throw new NotFoundError(`Release with releaseId ${releaseId} not found`)
 		}
@@ -119,8 +120,9 @@ export class DataSourceWrapper {
 		const releaseWithSprints = (await this.dataSource.getRepository(Release).find({
 			where: {id: releaseId},
 			relations:{
-				sprints: true
-			}}))
+				sprints: true // must sort by sprint.sprintNumber later
+			},
+		}))
 		if (!releaseWithSprints || releaseWithSprints.length === 0) {
 			throw new NotFoundError(`Release with releaseId ${releaseId} not found`)
 		}

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -142,12 +142,20 @@ export class Database {
 		return await this.releaseRepository.copyRelease(releaseId);
 	}
 
+	public async getReleaseSprints(releaseId: number): Promise<Sprint[]> {
+		return await this.releaseRepository.getReleaseSprints(releaseId)
+	}
+
 	public async lookupReleaseById(id: number): Promise<Release> {
 		return this.dataSource.lookupReleaseById(id);
 	}
 
-	public async lookupReleaseWithProject(releaseId: number): Promise<Release> {
-		return this.dataSource.lookupReleaseWithProject(releaseId);
+	public async fetchReleaseWithProject(releaseId: number): Promise<Release> {
+		return this.dataSource.fetchReleaseWithProject(releaseId);
+	}
+
+	public async fetchReleaseWithSprints(releaseId: number): Promise<Release> {
+		return this.dataSource.fetchReleaseWithSprints(releaseId);
 	}
 
 	///// Role Methods /////

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -151,15 +151,15 @@ export class Database {
 	}
 
 	public async lookupReleaseById(id: number): Promise<Release> {
-		return this.dataSource.lookupReleaseById(id);
+		return await this.dataSource.lookupReleaseById(id);
 	}
 
 	public async fetchReleaseWithProject(releaseId: number): Promise<Release> {
-		return this.dataSource.fetchReleaseWithProject(releaseId);
+		return await this.dataSource.fetchReleaseWithProject(releaseId);
 	}
 
 	public async fetchReleaseWithSprints(releaseId: number): Promise<Release> {
-		return this.dataSource.fetchReleaseWithSprints(releaseId);
+		return await this.dataSource.fetchReleaseWithSprints(releaseId);
 	}
 
 	///// Role Methods /////
@@ -188,6 +188,10 @@ export class Database {
 		
 	public async lookupSprintById(id: number): Promise<Sprint> {
 		return await this.dataSource.lookupSprintById(id);
+	}
+		
+	public async lookupSprintByIdWithRelease(id: number): Promise<Sprint> {
+		return await this.dataSource.lookupSprintByIdWithRelease(id);
 	}
 
 	///// BacklogItem Methods /////

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -150,6 +150,10 @@ export class Database {
 		return await this.releaseRepository.reorderSprints(releaseId, startIndex, destinationIndex)
 	}
 
+	public async removeSprintFromRelease(sprintId: number): Promise<Sprint[]> {
+		return await this.releaseRepository.removeSprintFromRelease(sprintId);
+	}
+
 	public async lookupReleaseById(id: number): Promise<Release> {
 		return await this.dataSource.lookupReleaseById(id);
 	}
@@ -189,9 +193,13 @@ export class Database {
 	public async lookupSprintById(id: number): Promise<Sprint> {
 		return await this.dataSource.lookupSprintById(id);
 	}
-		
+	
 	public async lookupSprintByIdWithRelease(id: number): Promise<Sprint> {
 		return await this.dataSource.lookupSprintByIdWithRelease(id);
+	}
+	
+	public async deleteSprint(id: number): Promise<void> {
+		return await this.dataSource.deleteSprint(id);
 	}
 
 	///// BacklogItem Methods /////

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -146,6 +146,10 @@ export class Database {
 		return await this.releaseRepository.getReleaseSprints(releaseId)
 	}
 
+	public async reorderSprints(releaseId: number, startIndex: number, destinationIndex: number): Promise<Sprint[]> {
+		return await this.releaseRepository.reorderSprints(releaseId, startIndex, destinationIndex)
+	}
+
 	public async lookupReleaseById(id: number): Promise<Release> {
 		return this.dataSource.lookupReleaseById(id);
 	}

--- a/backend/src/db/repositories/releaseRepository.ts
+++ b/backend/src/db/repositories/releaseRepository.ts
@@ -1,3 +1,4 @@
+import { Sprint } from "../../entity/sprint";
 import { Release } from "../../entity/release";
 import { DataSourceWrapper } from "../dataSourceWrapper";
 
@@ -28,7 +29,7 @@ export class ReleaseRepository {
 
 	public async updateRelease(releaseId: number, revisionDate?: Date, problemStatement?: string, goalStatement?: string): Promise<Release> {
 		const release = await this.dataSource.lookupReleaseById(releaseId)
-		// const releaseWithProject = await this.dataSource.lookupReleaseWithProject(releaseId)
+		// const releaseWithProject = await this.dataSource.fetchReleaseWithProject(releaseId)
 		// release.revision = revision ?? release.revision // shouldnt change
 		release.revisionDate = revisionDate ?? release.revisionDate
 		release.problemStatement = problemStatement ?? release.problemStatement
@@ -42,13 +43,18 @@ export class ReleaseRepository {
 		const releaseCopy = new Release();
 		// need to get the whole list of releases in this project so we can get the new version #
 		// should we just make a new variable to count the max version
-		const releaseWithProject = await this.dataSource.lookupReleaseWithProject(releaseId)
+		const releaseWithProject = await this.dataSource.fetchReleaseWithProject(releaseId)
 		releaseCopy.copy(releaseWithProject)
 		releaseCopy.revision = releaseCopy.project.nextRevision;
 		releaseCopy.project.nextRevision += 1;
 		await this.dataSource.save(releaseCopy.project)
 		await this.dataSource.save(releaseCopy)
 		return releaseCopy
+	}
+
+	public async getReleaseSprints(releaseId: number): Promise<Sprint[]> {
+		const releaseWithSprints = await this.dataSource.fetchReleaseWithSprints(releaseId)
+		return releaseWithSprints.sprints
 	}
 
 }

--- a/backend/src/router/sprint.ts
+++ b/backend/src/router/sprint.ts
@@ -1,9 +1,10 @@
 import express from "express";
-import { createSprint, editSprint} from '../controllers/sprint';
+import { createSprint, editSprint, getSprints} from '../controllers/sprint';
 import { errorWrapper } from '../helpers/errors';
 import { isAuthenticated } from "../middleware/index";
 
 export default (router: express.Router) => {
   router.post('/release/:releaseId/sprint', isAuthenticated, errorWrapper(createSprint));
   router.post('/sprint/:sprintId/edit', isAuthenticated, errorWrapper(editSprint));
+  router.get('/release/:releaseId/sprints', errorWrapper(getSprints));
 }

--- a/backend/src/router/sprint.ts
+++ b/backend/src/router/sprint.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import { createSprint, editSprint, getSprints} from '../controllers/sprint';
+import { createSprint, editSprint, getSprintWithRelease, getSprints, moveSprint} from '../controllers/sprint';
 import { errorWrapper } from '../helpers/errors';
 import { isAuthenticated } from "../middleware/index";
 
@@ -7,4 +7,6 @@ export default (router: express.Router) => {
   router.post('/release/:releaseId/sprint', isAuthenticated, errorWrapper(createSprint));
   router.post('/sprint/:sprintId/edit', isAuthenticated, errorWrapper(editSprint));
   router.get('/release/:releaseId/sprints', errorWrapper(getSprints));
+  router.get('/sprint/:sprintId', errorWrapper(getSprintWithRelease));
+  router.post('/release/:releaseId/reorder', errorWrapper(moveSprint));
 }

--- a/backend/src/router/sprint.ts
+++ b/backend/src/router/sprint.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import { createSprint, editSprint, getSprintWithRelease, getSprints, moveSprint} from '../controllers/sprint';
+import { createSprint, deleteSprint, editSprint, getSprintWithRelease, getSprints, moveSprint} from '../controllers/sprint';
 import { errorWrapper } from '../helpers/errors';
 import { isAuthenticated } from "../middleware/index";
 
@@ -9,4 +9,5 @@ export default (router: express.Router) => {
   router.get('/release/:releaseId/sprints', errorWrapper(getSprints));
   router.get('/sprint/:sprintId', errorWrapper(getSprintWithRelease));
   router.post('/release/:releaseId/reorder', errorWrapper(moveSprint));
+  router.delete('/sprint/:sprintId', isAuthenticated, errorWrapper(deleteSprint));
 }

--- a/backend/tests/router/sprint.test.ts
+++ b/backend/tests/router/sprint.test.ts
@@ -246,4 +246,17 @@ describe("Sprint API tests", () => {
 		});
 	});
 
+	test("Deleting a middle sprint so its just 3 2", async () => {
+		await request(app)
+		.delete(`/api/sprint/${sprintId}`)
+		.set('Cookie', [`user-auth=${sessionToken}`])
+		.expect(200)
+		.then((res) => {
+			expect(res.body).toBeDefined();
+			expect(res.body.length).toBe(2);
+			expect(res.body[0].id).toBe(sprint3Id);
+			expect(res.body[1].id).toBe(sprint2Id);
+		});
+	});
+
 });

--- a/backend/tests/router/sprint.test.ts
+++ b/backend/tests/router/sprint.test.ts
@@ -82,6 +82,8 @@ describe("Release API tests", () => {
 
 	let projectId: Number;
 	let sprintId: Number;
+	let sprint2Id: Number;
+	let sprint3Id: Number;
 	let releaseId: Number;
 
 	test('Create project', async () => {
@@ -152,6 +154,47 @@ describe("Release API tests", () => {
 			expect(res.body.goal).toEqual("New sprint goal")
 			expect(res.body.sprintNumber);
 
+		});
+	});
+
+	test('More Sprints', async () => {
+		const body = {"sprintNumber": 2, "startDate": "03/24/2023", "endDate": "03/25/2023", "goal": "New new sprint goal"}
+		await request(app)
+		.post(`/api/release/${releaseId}/sprint`)
+		.set('Cookie', [`user-auth=${sessionToken}`])
+		.send(body)
+		.expect(200)
+		.then((res) => {
+			expect(res.body).toBeDefined();
+			expect(res.body.id).toBeDefined();
+			sprint2Id = res.body.id;
+			expect(res.body.startDate).toBeDefined();
+		});
+		const body2 = {"sprintNumber": 3, "startDate": "03/25/2023", "endDate": "03/26/2023", "goal": "New new new sprint goal"}
+		await request(app)
+		.post(`/api/release/${releaseId}/sprint`)
+		.set('Cookie', [`user-auth=${sessionToken}`])
+		.send(body2)
+		.expect(200)
+		.then((res) => {
+			expect(res.body).toBeDefined();
+			expect(res.body.id).toBeDefined();
+			sprint3Id = res.body.id;
+			expect(res.body.startDate).toBeDefined();
+		});
+	});
+
+	test("The order of sprints is preserved", async () => {
+		await request(app)
+		.get(`/api/release/${releaseId}/sprints`)
+		.set('Cookie', [`user-auth=${sessionToken}`])
+		.expect(200)
+		.then((res) => {
+			expect(res.body).toBeDefined();
+			console.log(res.body)
+			expect(res.body[0].id).toBe(sprintId);
+			expect(res.body[1].id).toBe(sprint2Id);
+			expect(res.body[2].id).toBe(sprint3Id);
 		});
 	});
 });

--- a/backend/tests/router/sprint.test.ts
+++ b/backend/tests/router/sprint.test.ts
@@ -54,7 +54,7 @@ afterAll(async () => {
 	await server.close()
 });
 
-describe("Release API tests", () => {
+describe("Sprint API tests", () => {
   let sessionToken: string;
 	test("CREATE USER", async () => {
 		const body = {username: "sallyg", email: "sallys@gmail.com", password: "password123"}
@@ -184,17 +184,69 @@ describe("Release API tests", () => {
 		});
 	});
 
-	test("The order of sprints is preserved", async () => {
+	test("The order of sprints is ascending when getting sprints", async () => {
 		await request(app)
 		.get(`/api/release/${releaseId}/sprints`)
 		.set('Cookie', [`user-auth=${sessionToken}`])
 		.expect(200)
 		.then((res) => {
 			expect(res.body).toBeDefined();
-			console.log(res.body)
 			expect(res.body[0].id).toBe(sprintId);
 			expect(res.body[1].id).toBe(sprint2Id);
 			expect(res.body[2].id).toBe(sprint3Id);
 		});
 	});
+
+	test("Reorder sprints to be 3, 1, 2", async () => {
+		await request(app)
+		.post(`/api/release/${releaseId}/reorder`)
+		.set('Cookie', [`user-auth=${sessionToken}`])
+		.send({
+			sprintStartIndex: 2,
+            sprintEndIndex: 0
+		})
+		.expect(200)
+		.then((res) => {
+			expect(res.body).toBeDefined();
+			expect(res.body[0].id).toBe(sprint3Id);
+			expect(res.body[0].sprintNumber).toBe(1);
+			expect(res.body[1].id).toBe(sprintId);
+			expect(res.body[1].sprintNumber).toBe(2);
+			expect(res.body[2].id).toBe(sprint2Id);
+			expect(res.body[2].sprintNumber).toBe(3);
+		});
+	});
+
+	test("The new order of sprints is saved", async () => {
+		await request(app)
+		.get(`/api/release/${releaseId}/sprints`)
+		.set('Cookie', [`user-auth=${sessionToken}`])
+		.expect(200)
+		.then((res) => {
+			expect(res.body).toBeDefined();
+			expect(res.body[0].id).toBe(sprint3Id);
+			expect(res.body[0].sprintNumber).toBe(1);
+			expect(res.body[1].id).toBe(sprintId);
+			expect(res.body[1].sprintNumber).toBe(2);
+			expect(res.body[2].id).toBe(sprint2Id);
+			expect(res.body[2].sprintNumber).toBe(3);
+		});
+	});
+
+	test("Sprints still hav relation to the release", async () => {
+		await request(app)
+		.get(`/api/release/${releaseId}/sprints`)
+		.set('Cookie', [`user-auth=${sessionToken}`])
+		.expect(200)
+		.then((res) => {
+			expect(res.body).toBeDefined();
+			expect(res.body[0].id).toBe(sprint3Id);
+			expect(res.body[0].sprintNumber).toBe(1);
+			expect(res.body[1].id).toBe(sprintId);
+			expect(res.body[1].sprintNumber).toBe(2);
+			expect(res.body[2].id).toBe(sprint2Id);
+			expect(res.body[2].sprintNumber).toBe(3);
+		});
+	});
+
 });

--- a/backend/tests/router/sprint.test.ts
+++ b/backend/tests/router/sprint.test.ts
@@ -233,19 +233,16 @@ describe("Sprint API tests", () => {
 		});
 	});
 
-	test("Sprints still hav relation to the release", async () => {
+	test("Sprints still have relation to the release", async () => {
 		await request(app)
-		.get(`/api/release/${releaseId}/sprints`)
+		.get(`/api/sprint/${sprintId}`)
 		.set('Cookie', [`user-auth=${sessionToken}`])
 		.expect(200)
 		.then((res) => {
 			expect(res.body).toBeDefined();
-			expect(res.body[0].id).toBe(sprint3Id);
-			expect(res.body[0].sprintNumber).toBe(1);
-			expect(res.body[1].id).toBe(sprintId);
-			expect(res.body[1].sprintNumber).toBe(2);
-			expect(res.body[2].id).toBe(sprint2Id);
-			expect(res.body[2].sprintNumber).toBe(3);
+			expect(res.body.id).toBe(sprintId);
+			expect(res.body.sprintNumber).toBe(2);
+			expect(res.body.release.id).toBe(releaseId);
 		});
 	});
 


### PR DESCRIPTION
API + new db methods + unit test

When we add stories to the sprints, we will have to come back to this function in the backend to move them to the backlog.

Probably wait until the reordering PR is merged because this one builds off of that