### PR TITLE
Track signing backend

### DIFF
--- a/backend/src/entity/User.ts
+++ b/backend/src/entity/User.ts
@@ -2,6 +2,7 @@ import { Entity, PrimaryGeneratedColumn, Column, OneToMany, ManyToMany } from "t
 import { Project } from "./project"
 import { getMaybeUndefined, addMaybeUndefined, removeMaybeUndefined } from "./utils/addGetList"
 import { BacklogItem } from "./backlogItem"
+import { Release } from "./release"
 
 @Entity()
 export class User {
@@ -33,6 +34,9 @@ export class User {
 
 	@ManyToMany(() => Project, (project) => project.invitedUsers)
 	projectInvites: Project[]
+
+	@ManyToMany(() => Release, (release) => release.signatures)
+	signedReleases: Release[]
 
 	@ManyToMany(() => BacklogItem, (todo) => todo.assignees)
 	assignments: BacklogItem[]

--- a/backend/src/entity/release.ts
+++ b/backend/src/entity/release.ts
@@ -1,8 +1,9 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany, ManyToOne } from "typeorm"
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany, ManyToOne, ManyToMany, JoinTable } from "typeorm"
 import { Sprint } from "./sprint"
 import { Project } from "./project"
 import { BacklogItem } from "./backlogItem"
 import { addMaybeUndefined, getMaybeUndefined, removeMaybeUndefined } from "./utils/addGetList"
+import { User } from "./User"
 
 @Entity()
 export class Release {
@@ -25,6 +26,9 @@ export class Release {
 	@Column({ default: 0 })
 	backlogItemCount: number = 0
 
+	@Column()
+	fullySigned: boolean = false
+
 	///// Relational /////
 
 	@ManyToOne(() => Project, (project) => project.releases, { nullable: false })
@@ -32,6 +36,10 @@ export class Release {
 
 	@OneToMany(() => Sprint, (sprint) => sprint.release)
 	sprints: Sprint[]
+
+	@ManyToMany(() => User, (user) => user.signedReleases)
+	@JoinTable()
+	signatures: User[]
 
 	@OneToMany(() => BacklogItem, (backlog) => backlog.release)
 	backlog: BacklogItem[]


### PR DESCRIPTION
Added new column and relations to track signatures. each signed user will be added to the list. if they leave the project they'll be retroactively removed from all those releases. frontend can tell if its green by using the new column, or yellow by checking if the list of signatures is nonempty otherwise. If none of the above, then its gray

The API call used by sidebar is not also getting release signatures so it will be able to assign colors for each sidebar item.

No new tests this time, it's passing current tests and theres no API for signing yet.